### PR TITLE
Avoid using create_function()

### DIFF
--- a/check.php
+++ b/check.php
@@ -31,7 +31,9 @@ define('REGEX_IS_URL', '#^https?://[-A-Z0-9+&@\#/%?=~_|!:,.;]*[-A-Z0-9+&@#/%=~_|
 function find_links($text)
 {
     if (preg_match_all(REGEX_URL, $text, $m, PREG_SET_ORDER)) {
-        return array_unique(array_map(create_function('$m', 'return $m[0];'), $m));
+        return array_unique(array_map(function ($m) {
+            return $m[0];
+        }, $m));
     }
 
     return array();


### PR DESCRIPTION
create_function() should not be used as it's slow, executes eval() internally and it's a crap in general. This PR replaces it by a native anonymous function.
